### PR TITLE
Resolves SCPR/KPCC-iPad#13.

### DIFF
--- a/KPCC.xcodeproj/project.pbxproj
+++ b/KPCC.xcodeproj/project.pbxproj
@@ -6799,8 +6799,8 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
 				BUNDLE_ID = org.scpr.mobile.ipad;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Jason Georges (K7Q582A4SU)";
+				CODE_SIGN_IDENTITY = "iPhone Developer: Reed DeLapp (2L3CQSAF79)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Reed DeLapp (2L3CQSAF79)";
 				FACEBOOK_IDENTIFIER = 129848480405753;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -6834,7 +6834,7 @@
 				);
 				PLATFORM_STRING = ipad;
 				PRODUCT_NAME = KPCC;
-				PROVISIONING_PROFILE = "d3336d63-7042-43d8-ba08-da4f5db9686c";
+				PROVISIONING_PROFILE = "d6545178-9d31-44a5-bdf1-e8b2ca01aaf3";
 				TARGETED_DEVICE_FAMILY = 2;
 				UNIQUE_BUNDLE_VERSION = SANDBOX;
 				VALID_ARCHS = "armv7 armv7s arm64";
@@ -6885,7 +6885,7 @@
 				PRODUCT_NAME = KPCC;
 				PROVISIONING_PROFILE = "84cee567-7313-434c-8e1f-e3b9a1243ff0";
 				TARGETED_DEVICE_FAMILY = 2;
-				UNIQUE_BUNDLE_VERSION = "build 3";
+				UNIQUE_BUNDLE_VERSION = "RC 1";
 				VALID_ARCHS = "armv7 armv7s arm64";
 				VERSION = 1.0.7;
 				WRAPPER_EXTENSION = app;

--- a/KPCC/UI/ProgramPages/SCPRProgramNavigatorViewController.m
+++ b/KPCC/UI/ProgramPages/SCPRProgramNavigatorViewController.m
@@ -47,7 +47,9 @@
 }
 
 - (void)viewDidAppear:(BOOL)animated {
-
+  self.needsSnap = YES;
+  [self.view setNeedsLayout];
+  [self.view layoutIfNeeded];
 }
 
 - (void)setupWithPrograms:(NSArray *)programs {

--- a/KPCC/UI/SCPRViewController.m
+++ b/KPCC/UI/SCPRViewController.m
@@ -616,11 +616,6 @@ static NSString *kOndemandURL = @"http://media.scpr.org/audio/upload/2013/04/04/
   }
 
 
-
-  self.programPages.view.frame = CGRectMake(0.0,
-                                            0.0,
-                                            self.programPages.view.frame.size.width,
-                                            self.programPages.view.frame.size.height);
   [self snapToDisplayPortWithView:self.programPages.view];
   
   [[ContentManager shared] pushToResizeVector:self.programPages];


### PR DESCRIPTION
As with many of the xib-based loads across the app, the program navigator controller needs to be kicked into shape after it loads so that it fills its container.